### PR TITLE
Added dungenworld babele dialog

### DIFF
--- a/scripts/system-dungeonworld.js
+++ b/scripts/system-dungeonworld.js
@@ -1,5 +1,15 @@
 export function InitDUNGEONWORLD() {
-    if (typeof Babele !== "undefined") {
+    if (typeof Babele === "undefined") {
+        new Dialog({
+            title: "Перевод библиотек",
+            content: `<p>Для перевода библиотек системы Dungeon World требуется установить и активировать модуль Babele.<p>`,
+            buttons: {
+                done: {
+                    label: "Хорошо",
+                },
+            },
+        }).render(true);
+    } else {
         Babele.get().register({
             module: "ru-ru",
             lang: "ru",


### PR DESCRIPTION
## Проблема

Нет предупреждающего диалога о том, что нужен модуль Babele при активации модуля с переводом в мире с системой Dungeon World

## Решение

Копипастнуть из соседних модулей диалог

## Результат

Диалог начал появляться при загрузке мира с модулем перевода и без Babele

<img width="432" alt="Screenshot 2021-09-19 at 18 01 30" src="https://user-images.githubusercontent.com/12645407/133932393-e0a3d43a-8c49-437e-a94f-ec79f56cfdf4.png">