### PR TITLE
D&D 5e minor fixes in translation

### DIFF
--- a/public/i18n/systems/dnd5e.json
+++ b/public/i18n/systems/dnd5e.json
@@ -3034,7 +3034,7 @@
 					"hint": "Использовать эти значения дистанции вместо значений у предмета."
 				},
 				"reach": {
-					"label": "Длинное"
+					"label": "Досягаемость"
 				},
 				"special": {
 					"label": "Особая дистанция",
@@ -3052,7 +3052,7 @@
 		},
 		"Formatted": {
 			"Range": "дистанция {range}",
-			"Reach": "длинное {reach}"
+			"Reach": "зона досягаемости {reach}"
 		}
 	},
 
@@ -3273,7 +3273,7 @@
 	"DND5E.SavingThrow": "Испытание",
 	"DND5E.SavingThrowDC": "СЛ {dc} - испытание {ability}",
 	"DND5E.SavingThrowRoll": "Испытание {ability}",
-	"DND5E.SavingThrowShort": "Испыт.",
+	"DND5E.SavingThrowShort": "Исп.",
 	"DND5E.SaveDC": "СЛ {dc} - {ability}",
 	"DND5E.SavePromptTitle": "Испытание {ability}",
 	"DND5E.ScalingFormula": "Формула подъёма",


### PR DESCRIPTION
## Reach
React у оружия — это Длинное (свойство)
Reach в остальных случаях — зона досягаемости, но не везде поместится полностью, поэтому для краткости в некоторых местах просто досягаемость
## Save
Для красоты блока параметров нужно, чтобы название состояло из 3 букв, поэтому испыт. -> исп.
<hr>
<img width="484" alt="reach" src="https://github.com/user-attachments/assets/b771bb41-d855-4b3f-a9ab-a2116d2b12b3" />
<img width="606" alt="Screenshot 2025-06-12 at 11 07 30 PM" src="https://github.com/user-attachments/assets/61e8ac47-3563-47d7-b789-37353dac9197" />
<img width="481" alt="Screenshot 2025-06-12 at 11 08 15 PM" src="https://github.com/user-attachments/assets/7df77c54-ef50-46f4-91f4-b471443503b7" />
<img width="484" alt="Screenshot 2025-06-12 at 11 09 06 PM" src="https://github.com/user-attachments/assets/f60261ca-d1ba-4ea2-9700-15f885450420" />
